### PR TITLE
feat: add buildRaw() to WasapiClient.Builder

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,69 @@
+name: 📊 API Coverage Report
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🗂️ Checkout repository
+        uses: actions/checkout@v4
+
+      - name: ⚙️ Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: 🧩 Install dependencies
+        run: npm ci
+
+      - name: 🛠️ Build package
+        run: npm run build
+
+      - name: 📊 Generate & Post Table Report
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          REPORT_FORMAT: 'plain'
+        with:
+          script: |
+            const fs = require('fs');
+            const cp = require('child_process');
+
+            const config = {
+              table: { flag: 'github-table', header: 'Table report'},
+              plain: { flag: 'github-plain', header: 'Plain report' }
+            }[process.env.REPORT_FORMAT];
+
+            cp.execSync(`npx test-coverage --format=${config.flag}`);
+            const body = fs.readFileSync('test-coverage-report.md', 'utf-8');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes(config.header)
+            );
+
+            const commentPayload = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            };
+
+            if (existing) {
+              await github.rest.issues.updateComment({ ...commentPayload, comment_id: existing.id });
+            } else {
+              await github.rest.issues.createComment({ ...commentPayload, issue_number: context.issue.number });
+            }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: 🚀 Publish Package
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🗂️ Checkout repository
+        uses: actions/checkout@v4
+
+      - name: ⚙️ Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: https://registry.npmjs.org
+
+      - name: 🧩 Install dependencies
+        run: npm ci
+
+      - name: 🛠️ Build package
+        run: npm run build --if-present
+
+      - name: 🐳 Start BookHive API
+        run: |
+          git clone --depth 1 https://github.com/umutayb/book-hive.git /tmp/book-hive
+          cd /tmp/book-hive
+          docker compose up --build -d
+          cd $GITHUB_WORKSPACE
+
+      - name: ⏳ Wait for API readiness
+        run: |
+          for i in $(seq 1 30); do
+            if curl -s http://localhost:8080/api/health | grep -q '"healthy"'; then
+              echo "API is ready"
+              break
+            fi
+            echo "Waiting for API... ($i/30)"
+            sleep 2
+          done
+
+      - name: 🌱 Seed test data
+        run: curl -s -X POST http://localhost:8080/api/reset
+
+      - name: 🧪 Run All Tests
+        run: npx tsx tests/book-hive.test.ts
+
+      - name: 📦 Publish Package
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,57 @@
+name: 🧪 Test, Verify & Coverage
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🗂️ Checkout repository
+        uses: actions/checkout@v4
+
+      - name: ⚙️ Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: 🧩 Install dependencies
+        run: npm ci
+
+      - name: 🛠️ Build package
+        run: npm run build
+
+      - name: 🐳 Start BookHive API
+        run: |
+          git clone --depth 1 https://github.com/umutayb/book-hive.git /tmp/book-hive
+          cd /tmp/book-hive
+          docker compose up --build -d
+          cd $GITHUB_WORKSPACE
+
+      - name: ⏳ Wait for API readiness
+        run: |
+          for i in $(seq 1 30); do
+            if curl -s http://localhost:8080/api/health | grep -q '"healthy"'; then
+              echo "API is ready"
+              break
+            fi
+            echo "Waiting for API... ($i/30)"
+            sleep 2
+          done
+
+      - name: 🌱 Seed test data
+        run: curl -s -X POST http://localhost:8080/api/reset
+
+      - name: 🧪 Run Integration Tests
+        run: npx tsx tests/book-hive.test.ts
+
+      - name: 📝 Check Types
+        run: npx tsc --noEmit

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
-.idea/vcs.xml
-/out/
-/.idea/
-POM-Framework.iml
-*.iml
+/dist
+/node_modules
+*.tgz
 .DS_Store
-/inbox/
-src/test/resources/secret.properties
-/target/
-mongo-init.js
+.env
+.env.local

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Annotation profile for Wasapi" enabled="true">
+        <sourceOutputDir name="out/artifacts/wasapi_jar/generated-sources/annotations" />
+        <sourceTestOutputDir name="out/artifacts/wasapi_jar/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="wasapi" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,8 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="AutoCloseableResource" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="METHOD_MATCHER_CONFIG" value="java.util.Formatter,format,java.io.Writer,append,com.google.common.base.Preconditions,checkNotNull,org.hibernate.Session,close,java.io.PrintWriter,printf,java.io.PrintStream,printf,java.lang.foreign.Arena,ofAuto,java.lang.foreign.Arena,global,retrofit2.Response,errorBody" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Central Repository" />
+      <option name="url" value="https://repo.maven.apache.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1128 @@
+{
+  "name": "@civitas-cerebrum/wasapi",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@civitas-cerebrum/wasapi",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@civitas-cerebrum/context-store": "^0.0.2",
+        "@civitas-cerebrum/test-coverage": "^0.0.9",
+        "debug": "^4.4.3"
+      },
+      "devDependencies": {
+        "@types/debug": "^4.1.13",
+        "@types/node": "^20.0.0",
+        "tsx": "^4.21.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@civitas-cerebrum/context-store": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/context-store/-/context-store-0.0.2.tgz",
+      "integrity": "sha512-v5j/L1+ngS1hge5mmNtsIqby9c6+LPivlGn/VqDAzg06wAtNQ1uEy4bSTI4zyNovEh03MeNEzSNcz6Ob+2N40A==",
+      "license": "MIT"
+    },
+    "node_modules/@civitas-cerebrum/test-coverage": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@civitas-cerebrum/test-coverage/-/test-coverage-0.0.9.tgz",
+      "integrity": "sha512-+fnvV+dD2SnxbYAjlN9sI3oyh/VIzgW/T8Y6i7Y+Vttyw9DdJ3wesN+bWkxVGF8F1GAf4LKg1BRGlw5vjy5agQ==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.4.5",
+        "typescript": "^5.0.0"
+      },
+      "bin": {
+        "test-coverage": "dist/cli.js"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@civitas-cerebrum/wasapi",
+  "version": "0.0.1",
+  "description": "A lightweight REST API client library with fluent builder, typed responses, and decorator-based API definitions.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "npm run clean && tsc",
+    "test": "npx tsx tests/book-hive.test.ts",
+    "test:coverage": "npx test-coverage",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@civitas-cerebrum/context-store": "^0.0.2",
+    "@civitas-cerebrum/test-coverage": "^0.0.9",
+    "debug": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/debug": "^4.1.13",
+    "@types/node": "^20.0.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/civitas-cerebrum/wasapi.git"
+  },
+  "author": "Umut Ay Bora",
+  "license": "MIT"
+}

--- a/src/client/WasapiClient.ts
+++ b/src/client/WasapiClient.ts
@@ -1,0 +1,288 @@
+import { ContextStore } from '@civitas-cerebrum/context-store';
+import { ClientConfig, HttpMethod, RequestConfig } from '../models/types';
+import { ApiResponse } from '../models/ApiResponse';
+import { ApiCall } from '../models/ApiCall';
+import { WasapiException } from '../exceptions/WasapiException';
+import { httpMetadata } from '../decorators/http';
+import { log, createLogger } from '../logger/Logger';
+
+const BODY_METHODS = new Set([HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH]);
+
+export class WasapiClient {
+  readonly config: ClientConfig;
+
+  private constructor(config: ClientConfig) {
+    this.config = config;
+  }
+
+  async execute<T>(requestConfig: RequestConfig): Promise<ApiResponse<T>> {
+    const url = this.buildUrl(requestConfig);
+    const headers = { ...this.config.headers, ...requestConfig.headers };
+    const reqLog = createLogger('request');
+    const resLog = createLogger('response');
+
+    // Build fetch options
+    const init: RequestInit = {
+      method: typeof requestConfig.method === 'string' ? requestConfig.method : requestConfig.method,
+      headers,
+      redirect: this.config.followRedirects ? 'follow' : 'manual',
+    };
+
+    // Body
+    if (requestConfig.formData) {
+      init.body = requestConfig.formData;
+    } else if (requestConfig.body !== undefined) {
+      init.body = JSON.stringify(requestConfig.body);
+      if (!headers['Content-Type'] && !headers['content-type']) {
+        (init.headers as Record<string, string>)['Content-Type'] = 'application/json';
+      }
+    }
+
+    // Timeout via AbortController
+    const timeout = requestConfig.timeout ?? this.config.timeout;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout * 1000);
+    init.signal = controller.signal;
+
+    // Log request
+    if (this.config.logHeaders) {
+      reqLog('%s %s', requestConfig.method, url);
+      for (const [k, v] of Object.entries(headers)) {
+        reqLog('  %s: %s', k, v);
+      }
+    } else {
+      reqLog('%s %s', requestConfig.method, url);
+    }
+
+    if (this.config.logRequestBody && requestConfig.body !== undefined) {
+      reqLog('Body: %O', requestConfig.body);
+    }
+
+    try {
+      const res = await fetch(url, init);
+      clearTimeout(timer);
+
+      const apiResponse = await ApiResponse.fromFetch<T>(res);
+
+      // Log response
+      resLog('%d %s', apiResponse.status, apiResponse.statusText);
+
+      if (this.config.detailedLogging && apiResponse.rawBody) {
+        resLog('Body: %s', apiResponse.rawBody);
+      }
+
+      return apiResponse;
+    } catch (err: unknown) {
+      clearTimeout(timer);
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        throw new WasapiException(`Request timed out after ${timeout}s: ${requestConfig.method} ${url}`);
+      }
+      throw err;
+    }
+  }
+
+  private buildUrl(config: RequestConfig): string {
+    let path = config.path;
+
+    // Substitute path params — :param style
+    if (config.pathParams) {
+      for (const [key, value] of Object.entries(config.pathParams)) {
+        path = path.replace(`:${key}`, encodeURIComponent(value));
+      }
+    }
+
+    const base = this.config.baseUrl.replace(/\/+$/, '');
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    let url = `${base}${normalizedPath}`;
+
+    // Query params
+    if (config.queryParams) {
+      const params = new URLSearchParams(config.queryParams);
+      const qs = params.toString();
+      if (qs) {
+        url += `?${qs}`;
+      }
+    }
+
+    return url;
+  }
+
+  /**
+   * Build a typed API proxy from a decorated class.
+   * Mirrors Retrofit's `retrofit.create(Service.class)`.
+   */
+  build<T>(ApiClass: new () => T): T {
+    // Instantiate to trigger decorator registration
+    const instance = new ApiClass();
+    const client = this;
+
+    return new Proxy(instance as object, {
+      get(target, prop, receiver) {
+        const methodName = String(prop);
+        const meta = httpMetadata.get(ApiClass.prototype, methodName);
+
+        if (!meta) {
+          return Reflect.get(target, prop, receiver);
+        }
+
+        return (...args: unknown[]) => {
+          const hasBody = meta.hasBody ?? BODY_METHODS.has(meta.method as HttpMethod);
+
+          let body: unknown | undefined;
+          let pathParams: Record<string, string> | undefined;
+          let queryParams: Record<string, string> | undefined;
+          let options: { headers?: Record<string, string>; timeout?: number } | undefined;
+
+          if (hasBody) {
+            [body, pathParams, queryParams, options] = args as [
+              unknown,
+              Record<string, string>?,
+              Record<string, string>?,
+              { headers?: Record<string, string>; timeout?: number }?,
+            ];
+          } else {
+            [pathParams, queryParams, options] = args as [
+              Record<string, string>?,
+              Record<string, string>?,
+              { headers?: Record<string, string>; timeout?: number }?,
+            ];
+          }
+
+          const requestConfig: RequestConfig = {
+            method: meta.method,
+            path: meta.path,
+            body,
+            pathParams,
+            queryParams,
+            headers: options?.headers,
+            timeout: options?.timeout,
+          };
+
+          return new ApiCall(client, requestConfig);
+        };
+      },
+    }) as T;
+  }
+
+  static Builder = class Builder {
+    #baseUrl = '';
+    #headers: Record<string, string> = {};
+    #timeout = 60;
+    #proxy: { host: string; port: number } | null = null;
+    #hostnameVerification = true;
+    #logHeaders = true;
+    #logRequestBody = false;
+    #detailedLogging = false;
+    #followRedirects = false;
+
+    constructor(store?: ContextStore) {
+      if (store) {
+        this.#baseUrl = store.get<string>('wasapi.baseUrl', '');
+        this.#timeout = store.getNumber('wasapi.timeout', 60);
+        this.#logHeaders = store.getBoolean('wasapi.logHeaders', true);
+        this.#logRequestBody = store.getBoolean('wasapi.logRequestBody', false);
+        this.#detailedLogging = store.getBoolean('wasapi.detailedLogging', false);
+        this.#hostnameVerification = store.getBoolean('wasapi.hostnameVerification', true);
+        this.#followRedirects = store.getBoolean('wasapi.followRedirects', false);
+
+        const proxyHost = store.get<string>('wasapi.proxyHost', '');
+        if (proxyHost) {
+          this.#proxy = {
+            host: proxyHost,
+            port: store.getNumber('wasapi.proxyPort', 8888),
+          };
+        }
+      }
+    }
+
+    setBaseUrl(url: string): this {
+      this.#baseUrl = url;
+      return this;
+    }
+
+    setHeaders(headers: Record<string, string>): this {
+      this.#headers = { ...this.#headers, ...headers };
+      return this;
+    }
+
+    setTimeout(seconds: number): this {
+      this.#timeout = seconds;
+      return this;
+    }
+
+    setProxy(host: string, port: number): this {
+      this.#proxy = { host, port };
+      return this;
+    }
+
+    setHostnameVerification(enabled: boolean): this {
+      this.#hostnameVerification = enabled;
+      return this;
+    }
+
+    setLogHeaders(enabled: boolean): this {
+      this.#logHeaders = enabled;
+      return this;
+    }
+
+    setLogRequestBody(enabled: boolean): this {
+      this.#logRequestBody = enabled;
+      return this;
+    }
+
+    setDetailedLogging(enabled: boolean): this {
+      this.#detailedLogging = enabled;
+      return this;
+    }
+
+    setFollowRedirects(follow: boolean): this {
+      this.#followRedirects = follow;
+      return this;
+    }
+
+    build<T>(ApiClass: new () => T): T {
+      if (!this.#baseUrl) {
+        throw new WasapiException('baseUrl is required. Call setBaseUrl() before build().');
+      }
+
+      const config: ClientConfig = {
+        baseUrl: this.#baseUrl,
+        headers: this.#headers,
+        timeout: this.#timeout,
+        proxy: this.#proxy,
+        hostnameVerification: this.#hostnameVerification,
+        logHeaders: this.#logHeaders,
+        logRequestBody: this.#logRequestBody,
+        detailedLogging: this.#detailedLogging,
+        followRedirects: this.#followRedirects,
+      };
+
+      const client = new WasapiClient(config);
+      return client.build(ApiClass);
+    }
+
+    /**
+     * Returns a raw WasapiClient instance for direct execute() calls
+     * without needing a decorated API class.
+     */
+    buildRaw(): WasapiClient {
+      if (!this.#baseUrl) {
+        throw new WasapiException('baseUrl is required. Call setBaseUrl() before buildRaw().');
+      }
+
+      const config: ClientConfig = {
+        baseUrl: this.#baseUrl,
+        headers: this.#headers,
+        timeout: this.#timeout,
+        proxy: this.#proxy,
+        hostnameVerification: this.#hostnameVerification,
+        logHeaders: this.#logHeaders,
+        logRequestBody: this.#logRequestBody,
+        detailedLogging: this.#detailedLogging,
+        followRedirects: this.#followRedirects,
+      };
+
+      return new WasapiClient(config);
+    }
+  };
+}

--- a/src/collections/ResponsePair.ts
+++ b/src/collections/ResponsePair.ts
@@ -1,0 +1,13 @@
+export class ResponsePair<R, E> {
+  readonly response: R;
+  readonly errorBody: E | null;
+
+  constructor(response: R, errorBody: E | null) {
+    this.response = response;
+    this.errorBody = errorBody;
+  }
+
+  isError(): boolean {
+    return this.errorBody !== null;
+  }
+}

--- a/src/decorators/http.ts
+++ b/src/decorators/http.ts
@@ -1,0 +1,79 @@
+import { HttpMethod } from '../models/types';
+
+interface HttpMetadataEntry {
+  method: HttpMethod | string;
+  path: string;
+  hasBody?: boolean;
+}
+
+/**
+ * Metadata storage for HTTP decorator registration.
+ * Keyed by class prototype → method name → metadata.
+ */
+class HttpMetadataStore {
+  private store = new Map<object, Map<string, HttpMetadataEntry>>();
+
+  set(prototype: object, methodName: string, entry: HttpMetadataEntry): void {
+    if (!this.store.has(prototype)) {
+      this.store.set(prototype, new Map());
+    }
+    this.store.get(prototype)!.set(methodName, entry);
+  }
+
+  get(prototype: object, methodName: string): HttpMetadataEntry | undefined {
+    return this.store.get(prototype)?.get(methodName);
+  }
+}
+
+export const httpMetadata = new HttpMetadataStore();
+
+/**
+ * Creates a TC39 Stage 3 method decorator for a standard HTTP method.
+ */
+function createHttpDecorator(method: HttpMethod) {
+  return (path: string) => {
+    return (_target: unknown, context: ClassMethodDecoratorContext) => {
+      context.addInitializer(function (this: unknown) {
+        httpMetadata.set(
+          Object.getPrototypeOf(this as object) as object,
+          String(context.name),
+          { method, path },
+        );
+      });
+    };
+  };
+}
+
+/** `@GET('/path')` — HTTP GET request. Args: (pathParams?, queryParams?, options?) */
+export const GET = createHttpDecorator(HttpMethod.GET);
+
+/** `@POST('/path')` — HTTP POST request. Args: (body?, pathParams?, queryParams?, options?) */
+export const POST = createHttpDecorator(HttpMethod.POST);
+
+/** `@PUT('/path')` — HTTP PUT request. Args: (body?, pathParams?, queryParams?, options?) */
+export const PUT = createHttpDecorator(HttpMethod.PUT);
+
+/** `@DELETE('/path')` — HTTP DELETE request. Args: (pathParams?, queryParams?, options?) */
+export const DELETE = createHttpDecorator(HttpMethod.DELETE);
+
+/** `@PATCH('/path')` — HTTP PATCH request. Args: (body?, pathParams?, queryParams?, options?) */
+export const PATCH = createHttpDecorator(HttpMethod.PATCH);
+
+/**
+ * `@HTTP('PURGE', '/cache/:key')` — Custom HTTP method decorator.
+ *
+ * @param method - The HTTP method string (e.g., 'PURGE', 'COPY', 'LOCK').
+ * @param path - The URL path template.
+ * @param hasBody - Whether the first argument is a request body. Default: false.
+ */
+export function HTTP(method: string, path: string, hasBody = false) {
+  return (_target: unknown, context: ClassMethodDecoratorContext) => {
+    context.addInitializer(function (this: unknown) {
+      httpMetadata.set(
+        Object.getPrototypeOf(this as object) as object,
+        String(context.name),
+        { method, path, hasBody },
+      );
+    });
+  };
+}

--- a/src/exceptions/FailedCallException.ts
+++ b/src/exceptions/FailedCallException.ts
@@ -1,0 +1,15 @@
+import { WasapiException } from './WasapiException';
+
+export class FailedCallException extends WasapiException {
+  readonly statusCode: number;
+  readonly responseBody: string;
+  readonly url: string;
+
+  constructor(message: string, statusCode: number, responseBody: string, url: string) {
+    super(message);
+    this.name = 'FailedCallException';
+    this.statusCode = statusCode;
+    this.responseBody = responseBody;
+    this.url = url;
+  }
+}

--- a/src/exceptions/WasapiException.ts
+++ b/src/exceptions/WasapiException.ts
@@ -1,0 +1,6 @@
+export class WasapiException extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WasapiException';
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,20 @@
+// Client
+export { WasapiClient } from './client/WasapiClient';
+
+// Models
+export { ApiCall } from './models/ApiCall';
+export { ApiResponse } from './models/ApiResponse';
+export type { HttpMethod, RequestConfig, ClientConfig, CallOptions } from './models/types';
+
+// Decorators
+export { GET, POST, PUT, DELETE, PATCH, HTTP } from './decorators/http';
+
+// Collections
+export { ResponsePair } from './collections/ResponsePair';
+
+// Exceptions
+export { FailedCallException } from './exceptions/FailedCallException';
+export { WasapiException } from './exceptions/WasapiException';
+
+// Logger
+export { log, createLogger } from './logger/Logger';

--- a/src/logger/Logger.ts
+++ b/src/logger/Logger.ts
@@ -1,0 +1,36 @@
+import Debug from "debug";
+
+const PREFIX = 'wasapi';
+
+const logsDisabled = process.env.WASAPI_DEBUG === 'false';
+
+if (!logsDisabled && !process.env.DEBUG) {
+  Debug.enable(`${PREFIX}:*`);
+}
+
+const NAMESPACE_PAD = 9;
+
+export function createLogger(namespace: string): Debug.Debugger {
+  const padded = namespace.padEnd(NAMESPACE_PAD);
+  return Debug(`${PREFIX}:${padded}`);
+}
+
+export const logger = (type: string): Debug.Debugger => {
+  const log = createLogger(`${type}`);
+  log.color = {
+    info:      '75',
+    warn:      '214',
+    error:     '203',
+    success:   '78',
+    important: '177',
+  }[type] || log.color;
+  return log;
+};
+
+export const log = {
+  info: logger('info'),
+  warn: logger('warn'),
+  error: logger('error'),
+  success: logger('success'),
+  important: logger('important'),
+};

--- a/src/models/ApiCall.ts
+++ b/src/models/ApiCall.ts
@@ -1,0 +1,193 @@
+import type { WasapiClient } from '../client/WasapiClient';
+import { RequestConfig } from './types';
+import { ApiResponse } from './ApiResponse';
+import { ResponsePair } from '../collections/ResponsePair';
+import { FailedCallException } from '../exceptions/FailedCallException';
+import { WasapiException } from '../exceptions/WasapiException';
+import { log } from '../logger/Logger';
+
+export class ApiCall<T> {
+  private readonly client: WasapiClient;
+  private readonly config: RequestConfig;
+
+  constructor(client: WasapiClient, config: RequestConfig) {
+    this.client = client;
+    this.config = { ...config };
+  }
+
+  /** Create an independent copy of this call for retry/polling. */
+  clone(): ApiCall<T> {
+    return new ApiCall<T>(this.client, { ...this.config });
+  }
+
+  get method(): string {
+    return typeof this.config.method === 'string'
+      ? this.config.method
+      : this.config.method;
+  }
+
+  get path(): string {
+    return this.config.path;
+  }
+
+  /**
+   * Execute the request and return the parsed body.
+   *
+   * @param strict - If true, throws FailedCallException on non-2xx. Default: false.
+   * @param printBody - If true, logs the response body. Default: false.
+   * @param errorModels - Constructor functions to try deserializing the error body.
+   * @returns The parsed response body, or null in lenient mode on failure.
+   */
+  async perform(strict = false, printBody = false, ...errorModels: Array<new () => unknown>): Promise<T | null> {
+    const response = await this.client.execute<T>(this.config);
+
+    if (printBody && response.rawBody) {
+      log.info('Response body: %s', response.rawBody);
+    }
+
+    if (response.isSuccessful()) {
+      return response.body;
+    }
+
+    // Failed response
+    if (strict) {
+      throw new FailedCallException(
+        `${this.config.method} ${this.config.path} failed with ${response.status} ${response.statusText}`,
+        response.status,
+        response.rawBody,
+        this.config.path,
+      );
+    }
+
+    // Lenient mode — try to deserialize error body
+    if (errorModels.length > 0 && response.rawBody) {
+      for (const Model of errorModels) {
+        try {
+          const parsed = JSON.parse(response.rawBody) as Record<string, unknown>;
+          return Object.assign(new Model() as object, parsed) as T | null;
+        } catch {
+          continue;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Execute and return the full ApiResponse wrapper.
+   */
+  async getResponse(strict = false, printBody = false): Promise<ApiResponse<T>> {
+    const response = await this.client.execute<T>(this.config);
+
+    if (printBody && response.rawBody) {
+      log.info('Response body: %s', response.rawBody);
+    }
+
+    if (!response.isSuccessful() && strict) {
+      throw new FailedCallException(
+        `${this.config.method} ${this.config.path} failed with ${response.status} ${response.statusText}`,
+        response.status,
+        response.rawBody,
+        this.config.path,
+      );
+    }
+
+    return response;
+  }
+
+  /**
+   * Execute and return a ResponsePair with typed error deserialization.
+   */
+  async getResponsePair<E extends object>(ErrorClass: new () => E): Promise<ResponsePair<ApiResponse<T>, E | null>> {
+    const response = await this.client.execute<T>(this.config);
+
+    if (response.isSuccessful()) {
+      return new ResponsePair(response, null);
+    }
+
+    const errorBody = response.errorBody<E>(ErrorClass);
+    return new ResponsePair(response, errorBody);
+  }
+
+  /**
+   * Poll until the response returns the expected HTTP status code.
+   *
+   * @param expectedCode - The HTTP status code to wait for.
+   * @param timeout - Maximum time to wait in milliseconds.
+   * @param interval - Polling interval in milliseconds. Default: 1000.
+   */
+  async monitorResponseCode(
+    expectedCode: number,
+    timeout: number,
+    interval = 1000,
+  ): Promise<ApiResponse<T>> {
+    const deadline = Date.now() + timeout;
+
+    while (Date.now() < deadline) {
+      const response = await this.clone().client.execute<T>(this.config);
+
+      if (response.status === expectedCode) {
+        log.success('Response code matched: %d', expectedCode);
+        return response;
+      }
+
+      log.info('Waiting for %d, got %d — retrying in %dms', expectedCode, response.status, interval);
+      await sleep(interval);
+    }
+
+    throw new WasapiException(
+      `Timed out after ${timeout}ms waiting for response code ${expectedCode} on ${this.config.method} ${this.config.path}`,
+    );
+  }
+
+  /**
+   * Poll until a field in the response body matches the expected value.
+   *
+   * @param fieldPath - Dot-notation path to the field (e.g., 'status' or 'data.state').
+   * @param expectedValue - The value to match against (compared via string coercion).
+   * @param timeout - Maximum time to wait in milliseconds.
+   * @param interval - Polling interval in milliseconds. Default: 1000.
+   */
+  async monitorFieldValue(
+    fieldPath: string,
+    expectedValue: unknown,
+    timeout: number,
+    interval = 1000,
+  ): Promise<T> {
+    const deadline = Date.now() + timeout;
+
+    while (Date.now() < deadline) {
+      const response = await this.clone().client.execute<T>(this.config);
+
+      if (response.body !== null) {
+        const actual = getNestedField(response.body, fieldPath);
+        if (String(actual) === String(expectedValue)) {
+          log.success('Field "%s" matched: %s', fieldPath, expectedValue);
+          return response.body;
+        }
+        log.info('Field "%s" = %s, expected %s — retrying in %dms', fieldPath, actual, expectedValue, interval);
+      }
+
+      await sleep(interval);
+    }
+
+    throw new WasapiException(
+      `Timed out after ${timeout}ms waiting for field "${fieldPath}" to equal "${expectedValue}" on ${this.config.method} ${this.config.path}`,
+    );
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function getNestedField(obj: unknown, path: string): unknown {
+  const parts = path.split('.');
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}

--- a/src/models/ApiResponse.ts
+++ b/src/models/ApiResponse.ts
@@ -1,0 +1,68 @@
+export class ApiResponse<T> {
+  readonly status: number;
+  readonly statusText: string;
+  readonly headers: Record<string, string>;
+  readonly ok: boolean;
+  readonly body: T | null;
+  readonly rawBody: string;
+
+  constructor(
+    status: number,
+    statusText: string,
+    headers: Record<string, string>,
+    ok: boolean,
+    body: T | null,
+    rawBody: string,
+  ) {
+    this.status = status;
+    this.statusText = statusText;
+    this.headers = headers;
+    this.ok = ok;
+    this.body = body;
+    this.rawBody = rawBody;
+  }
+
+  isSuccessful(): boolean {
+    return this.ok;
+  }
+
+  errorBody<E extends object>(ErrorClass?: new () => E): E | null {
+    if (this.ok) return null;
+    if (!this.rawBody) return null;
+
+    try {
+      const parsed = JSON.parse(this.rawBody) as Record<string, unknown>;
+      if (ErrorClass) {
+        return Object.assign(new ErrorClass(), parsed) as E;
+      }
+      return parsed as unknown as E;
+    } catch {
+      return null;
+    }
+  }
+
+  static async fromFetch<T>(res: globalThis.Response): Promise<ApiResponse<T>> {
+    const headers: Record<string, string> = {};
+    res.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+
+    const rawBody = await res.text();
+    let body: T | null = null;
+
+    try {
+      body = JSON.parse(rawBody) as T;
+    } catch {
+      // Non-JSON response — body stays null, rawBody has the text
+    }
+
+    return new ApiResponse<T>(
+      res.status,
+      res.statusText,
+      headers,
+      res.ok,
+      body,
+      rawBody,
+    );
+  }
+}

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,0 +1,37 @@
+export enum HttpMethod {
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  DELETE = 'DELETE',
+  PATCH = 'PATCH',
+  OPTIONS = 'OPTIONS',
+  HEAD = 'HEAD',
+}
+
+export interface RequestConfig {
+  method: HttpMethod | string;
+  path: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+  queryParams?: Record<string, string>;
+  pathParams?: Record<string, string>;
+  formData?: FormData;
+  timeout?: number;
+}
+
+export interface ClientConfig {
+  baseUrl: string;
+  headers: Record<string, string>;
+  timeout: number;
+  proxy: { host: string; port: number } | null;
+  hostnameVerification: boolean;
+  logHeaders: boolean;
+  logRequestBody: boolean;
+  detailedLogging: boolean;
+  followRedirects: boolean;
+}
+
+export interface CallOptions {
+  headers?: Record<string, string>;
+  timeout?: number;
+}

--- a/test-coverage-report.txt
+++ b/test-coverage-report.txt
@@ -1,0 +1,26 @@
+
+=== API COVERAGE REPORT ===
+
+ApiCall: 6/6
+  [x] clone
+  [x] perform
+  [x] getResponse
+  [x] getResponsePair
+  [x] monitorResponseCode
+  [x] monitorFieldValue
+
+ApiResponse: 3/3
+  [x] isSuccessful
+  [x] errorBody
+  [x] fromFetch
+
+ResponsePair: 1/1
+  [x] isError
+
+WasapiClient: 2/2
+  [x] execute
+  [x] build
+
+OVERALL: 12/12 (100.0%)
+THRESHOLD: 100%
+STATUS: PASSED

--- a/tests/book-hive.test.ts
+++ b/tests/book-hive.test.ts
@@ -1,0 +1,474 @@
+import { WasapiClient, GET, POST, PUT, DELETE, ApiCall, ApiResponse, ResponsePair, FailedCallException } from '../src/index';
+
+// ── Response Models ──────────────────────────────────────────────
+
+interface AuthResponse {
+  token: string;
+  userId: string;
+  username: string;
+  email: string;
+  balance: number;
+}
+
+interface Book {
+  id: string;
+  title: string;
+  author: string;
+  genre: string;
+  description: string;
+  price: number;
+  coverImage: string;
+  stock: number;
+  isbn: string;
+}
+
+interface Page<T> {
+  content: T[];
+  totalPages: number;
+  totalElements: number;
+  first: boolean;
+  last: boolean;
+  size: number;
+  number: number;
+  numberOfElements: number;
+  empty: boolean;
+}
+
+interface CartItem {
+  id: string;
+  userId: string;
+  bookId: string;
+  quantity: number;
+  addedAt: string;
+}
+
+interface Order {
+  id: string;
+  userId: string;
+  items: { bookId: string; quantity: number; priceAtPurchase: number }[];
+  totalPrice: number;
+  status: string;
+  purchasedAt: string;
+}
+
+interface MarketplaceListing {
+  id: string;
+  sellerId: string;
+  bookId: string;
+  condition: string;
+  price: number;
+  listedAt: string;
+  status: string;
+}
+
+interface HealthResponse {
+  status: string;
+  db: string;
+}
+
+interface StatusResponse {
+  status: string;
+}
+
+class ErrorBody {
+  message?: string;
+  error?: string;
+  status?: number;
+}
+
+// ── API Definitions ──────────────────────────────────────────────
+
+class HealthApi {
+  @GET('/api/health')
+  health(): ApiCall<HealthResponse> { return null!; }
+
+  @POST('/api/seed')
+  seed(): ApiCall<StatusResponse> { return null!; }
+
+  @POST('/api/reset')
+  reset(): ApiCall<StatusResponse> { return null!; }
+}
+
+class AuthApi {
+  @POST('/api/auth/signup')
+  signup(body: { username: string; email: string; password: string }): ApiCall<AuthResponse> { return null!; }
+
+  @POST('/api/auth/login')
+  login(body: { email: string; password: string }): ApiCall<AuthResponse> { return null!; }
+
+  @GET('/api/auth/me')
+  me(): ApiCall<AuthResponse> { return null!; }
+
+  @POST('/api/auth/logout')
+  logout(): ApiCall<void> { return null!; }
+}
+
+class BooksApi {
+  @GET('/api/books')
+  list(pathParams?: Record<string, string>, queryParams?: Record<string, string>): ApiCall<Page<Book>> { return null!; }
+
+  @GET('/api/books/:id')
+  getById(pathParams: { id: string }): ApiCall<Book> { return null!; }
+}
+
+class CartApi {
+  @GET('/api/cart')
+  get(): ApiCall<CartItem[]> { return null!; }
+
+  @POST('/api/cart/items')
+  addItem(body: { bookId: string; quantity: number }): ApiCall<CartItem> { return null!; }
+
+  @PUT('/api/cart/items/:id')
+  updateItem(body: { quantity: number }, pathParams: { id: string }): ApiCall<CartItem> { return null!; }
+
+  @DELETE('/api/cart/items/:id')
+  removeItem(pathParams: { id: string }): ApiCall<void> { return null!; }
+
+  @DELETE('/api/cart')
+  clear(): ApiCall<void> { return null!; }
+}
+
+class OrdersApi {
+  @POST('/api/orders')
+  checkout(body?: unknown): ApiCall<Order> { return null!; }
+
+  @GET('/api/orders')
+  list(): ApiCall<Order[]> { return null!; }
+
+  @GET('/api/orders/:id')
+  getById(pathParams: { id: string }): ApiCall<Order> { return null!; }
+
+  @POST('/api/orders/:id/return')
+  returnOrder(body: unknown, pathParams: { id: string }): ApiCall<Order> { return null!; }
+}
+
+class MarketplaceApi {
+  @GET('/api/marketplace')
+  list(): ApiCall<MarketplaceListing[]> { return null!; }
+
+  @POST('/api/marketplace/listings')
+  create(body: { bookId: string; condition: string; price: number }): ApiCall<MarketplaceListing> { return null!; }
+
+  @POST('/api/marketplace/listings/:id/buy')
+  buy(body: unknown, pathParams: { id: string }): ApiCall<MarketplaceListing> { return null!; }
+
+  @DELETE('/api/marketplace/listings/:id')
+  cancel(pathParams: { id: string }): ApiCall<void> { return null!; }
+}
+
+// ── Test Helpers ─────────────────────────────────────────────────
+
+const BASE_URL = 'http://localhost:8080';
+
+function buildPublicApi<T>(ApiClass: new () => T): T {
+  return new WasapiClient.Builder()
+    .setBaseUrl(BASE_URL)
+    .setLogHeaders(false)
+    .build(ApiClass);
+}
+
+function buildAuthApi<T>(ApiClass: new () => T, token: string): T {
+  return new WasapiClient.Builder()
+    .setBaseUrl(BASE_URL)
+    .setHeaders({ Authorization: `Bearer ${token}` })
+    .setLogHeaders(false)
+    .build(ApiClass);
+}
+
+// ── Tests ────────────────────────────────────────────────────────
+
+async function main() {
+  let passed = 0;
+  let failed = 0;
+
+  async function test(name: string, fn: () => Promise<void>) {
+    try {
+      await fn();
+      console.log(`  ✓ ${name}`);
+      passed++;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(`  ✗ ${name}`);
+      console.log(`    ${msg}`);
+      failed++;
+    }
+  }
+
+  function assert(condition: boolean, message: string) {
+    if (!condition) throw new Error(`Assertion failed: ${message}`);
+  }
+
+  // ── Setup ──
+  const healthApi = buildPublicApi(HealthApi);
+  const booksApi = buildPublicApi(BooksApi);
+
+  // Reset DB
+  await healthApi.reset().perform(true, false);
+
+  // ── Health & Seed ──
+  console.log('\n── Health & Seed ──');
+
+  await test('GET /api/health — perform() returns parsed body', async () => {
+    const body = await healthApi.health().perform(true);
+    assert(body !== null, 'body should not be null');
+    assert(body!.status === 'healthy', `expected "healthy", got "${body!.status}"`);
+    assert(body!.db === 'connected', `expected "connected", got "${body!.db}"`);
+  });
+
+  await test('POST /api/seed — perform() strict mode', async () => {
+    const body = await healthApi.seed().perform(true);
+    assert(body !== null, 'body should not be null');
+    assert(body!.status === 'seeded', `expected "seeded", got "${body!.status}"`);
+  });
+
+  // ── ApiCall.getResponse() ──
+  console.log('\n── ApiCall.getResponse() ──');
+
+  await test('getResponse() returns full ApiResponse wrapper', async () => {
+    const resp = await healthApi.health().getResponse();
+    assert(resp.status === 200, `expected 200, got ${resp.status}`);
+    assert(resp.ok === true, 'expected ok to be true');
+    assert(resp.body !== null, 'body should not be null');
+    assert(resp.headers['content-type']?.includes('application/json') === true, 'expected JSON content-type');
+    assert(typeof resp.rawBody === 'string', 'rawBody should be string');
+    assert(resp.isSuccessful() === true, 'isSuccessful should return true');
+  });
+
+  // ── ApiCall.clone() ──
+  console.log('\n── ApiCall.clone() ──');
+
+  await test('clone() creates independent copy that executes independently', async () => {
+    const call1 = healthApi.health();
+    const call2 = call1.clone();
+    const [resp1, resp2] = await Promise.all([call1.perform(true), call2.perform(true)]);
+    assert(resp1!.status === 'healthy', 'original should work');
+    assert(resp2!.status === 'healthy', 'clone should work');
+  });
+
+  // ── Books — GET with path params and query params ──
+  console.log('\n── Books ──');
+
+  await test('GET /api/books — list with pagination query params', async () => {
+    const body = await booksApi.list(undefined, { page: '0', size: '5' }).perform(true);
+    assert(body !== null, 'body should not be null');
+    assert(body!.content.length <= 5, `expected at most 5 items, got ${body!.content.length}`);
+    assert(body!.totalElements === 50, `expected 50 total, got ${body!.totalElements}`);
+    assert(body!.size === 5, `expected page size 5, got ${body!.size}`);
+  });
+
+  await test('GET /api/books — search by query param', async () => {
+    const body = await booksApi.list(undefined, { query: 'Mockingbird' }).perform(true);
+    assert(body !== null, 'body should not be null');
+    assert(body!.content.length > 0, 'expected at least 1 result');
+    assert(body!.content[0].title.includes('Mockingbird'), `expected title with "Mockingbird"`);
+  });
+
+  await test('GET /api/books/:id — path param substitution', async () => {
+    const book = await booksApi.getById({ id: 'book-001' }).perform(true);
+    assert(book !== null, 'body should not be null');
+    assert(book!.id === 'book-001', `expected "book-001", got "${book!.id}"`);
+    assert(typeof book!.title === 'string', 'title should be string');
+    assert(typeof book!.price === 'number', 'price should be number');
+  });
+
+  // ── Strict mode — FailedCallException ──
+  console.log('\n── Strict / Lenient Modes ──');
+
+  await test('strict mode throws FailedCallException on 404', async () => {
+    try {
+      await booksApi.getById({ id: 'nonexistent-book' }).perform(true);
+      assert(false, 'should have thrown');
+    } catch (err) {
+      assert(err instanceof FailedCallException, `expected FailedCallException, got ${(err as Error).constructor.name}`);
+      assert((err as FailedCallException).statusCode === 404, `expected 404, got ${(err as FailedCallException).statusCode}`);
+    }
+  });
+
+  await test('lenient mode returns null on 404', async () => {
+    const result = await booksApi.getById({ id: 'nonexistent-book' }).perform(false);
+    assert(result === null, 'expected null in lenient mode');
+  });
+
+  // ── ApiCall.getResponsePair() ──
+  console.log('\n── getResponsePair() ──');
+
+  await test('getResponsePair returns ResponsePair with error body on failure', async () => {
+    const pair = await booksApi.getById({ id: 'nonexistent' }).getResponsePair(ErrorBody);
+    assert(pair instanceof ResponsePair, 'should be ResponsePair');
+    assert(pair.response.status === 404, `expected 404, got ${pair.response.status}`);
+    assert(pair.isError() || pair.errorBody === null, 'should have error or null errorBody');
+  });
+
+  await test('getResponsePair returns no error on success', async () => {
+    const pair = await healthApi.health().getResponsePair(ErrorBody);
+    assert(pair.response.ok === true, 'response should be ok');
+    assert(pair.errorBody === null, 'errorBody should be null on success');
+    assert(pair.isError() === false, 'isError should be false');
+  });
+
+  // ── Auth — signup, login, me ──
+  console.log('\n── Auth ──');
+
+  const authApi = buildPublicApi(AuthApi);
+  let token1: string;
+  let userId1: string;
+
+  await test('POST /api/auth/login — get JWT token', async () => {
+    const body = await authApi.login({ email: 'testuser1@bookhive.test', password: 'Test1234!' }).perform(true);
+    assert(body !== null, 'body should not be null');
+    assert(typeof body!.token === 'string', 'token should be string');
+    assert(body!.email === 'testuser1@bookhive.test', 'email should match');
+    token1 = body!.token;
+    userId1 = body!.userId;
+  });
+
+  await test('GET /api/auth/me — authenticated request with JWT header', async () => {
+    const authedAuth = buildAuthApi(AuthApi, token1);
+    const body = await authedAuth.me().perform(true);
+    assert(body !== null, 'body should not be null');
+    assert(body!.userId === userId1, `userId should match`);
+    assert(body!.email === 'testuser1@bookhive.test', 'email should match');
+  });
+
+  // ── Cart — full CRUD ──
+  console.log('\n── Cart ──');
+
+  const cartApi = buildAuthApi(CartApi, token1);
+  let cartItemId: string;
+
+  await test('POST /api/cart/items — add item to cart', async () => {
+    const item = await cartApi.addItem({ bookId: 'book-001', quantity: 1 }).perform(true);
+    assert(item !== null, 'body should not be null');
+    assert(item!.bookId === 'book-001', 'bookId should match');
+    assert(item!.quantity === 1, 'quantity should be 1');
+    cartItemId = item!.id;
+  });
+
+  await test('GET /api/cart — list cart items', async () => {
+    const items = await cartApi.get().perform(true);
+    assert(items !== null, 'body should not be null');
+    assert(items!.length >= 1, 'cart should have at least 1 item');
+  });
+
+  await test('PUT /api/cart/items/:id — update quantity', async () => {
+    const updated = await cartApi.updateItem({ quantity: 2 }, { id: cartItemId }).perform(true);
+    assert(updated !== null, 'body should not be null');
+    assert(updated!.quantity === 2, `expected quantity 2, got ${updated!.quantity}`);
+  });
+
+  await test('DELETE /api/cart/items/:id — remove single item', async () => {
+    const resp = await cartApi.removeItem({ id: cartItemId }).getResponse(true);
+    assert(resp.status === 200, `expected 200, got ${resp.status}`);
+  });
+
+  await test('DELETE /api/cart — clear entire cart', async () => {
+    await cartApi.addItem({ bookId: 'book-002', quantity: 1 }).perform(true);
+    const resp = await cartApi.clear().getResponse(true);
+    assert(resp.status === 200, `expected 200, got ${resp.status}`);
+    const items = await cartApi.get().perform(true);
+    assert(items!.length === 0, `expected empty cart, got ${items!.length} items`);
+  });
+
+  // ── Orders — checkout + return ──
+  console.log('\n── Orders ──');
+
+  const ordersApi = buildAuthApi(OrdersApi, token1);
+  let orderId: string;
+
+  await test('POST /api/orders — checkout creates order', async () => {
+    // Add item to cart first
+    await cartApi.addItem({ bookId: 'book-003', quantity: 1 }).perform(true);
+    const order = await ordersApi.checkout({}).perform(true);
+    assert(order !== null, 'body should not be null');
+    assert(order!.status === 'COMPLETED', `expected COMPLETED, got ${order!.status}`);
+    assert(order!.items.length === 1, 'should have 1 item');
+    assert(order!.items[0].bookId === 'book-003', 'bookId should match');
+    orderId = order!.id;
+  });
+
+  await test('GET /api/orders — list user orders', async () => {
+    const orders = await ordersApi.list().perform(true);
+    assert(orders !== null, 'body should not be null');
+    assert(orders!.length >= 1, 'should have at least 1 order');
+  });
+
+  await test('GET /api/orders/:id — get order by ID', async () => {
+    const order = await ordersApi.getById({ id: orderId }).perform(true);
+    assert(order !== null, 'body should not be null');
+    assert(order!.id === orderId, 'orderId should match');
+  });
+
+  await test('POST /api/orders/:id/return — return order', async () => {
+    const returned = await ordersApi.returnOrder({}, { id: orderId }).perform(true);
+    assert(returned !== null, 'body should not be null');
+    assert(returned!.status === 'RETURNED', `expected RETURNED, got ${returned!.status}`);
+  });
+
+  // ── Marketplace ──
+  console.log('\n── Marketplace ──');
+
+  const marketApi1 = buildAuthApi(MarketplaceApi, token1);
+  let listingId: string;
+
+  await test('POST /api/marketplace/listings — create listing', async () => {
+    const listing = await marketApi1.create({ bookId: 'book-010', condition: 'GOOD', price: 7.99 }).perform(true);
+    assert(listing !== null, 'body should not be null');
+    assert(listing!.status === 'ACTIVE', `expected ACTIVE, got ${listing!.status}`);
+    assert(listing!.condition === 'GOOD', 'condition should match');
+    listingId = listing!.id;
+  });
+
+  await test('GET /api/marketplace — list active listings', async () => {
+    const listings = await marketApi1.list().perform(true);
+    assert(listings !== null, 'body should not be null');
+    assert(listings!.length >= 1, 'should have at least 1 listing');
+  });
+
+  await test('POST /api/marketplace/listings/:id/buy — buy listing', async () => {
+    // Login as user2 to buy
+    const user2Auth = await authApi.login({ email: 'testuser2@bookhive.test', password: 'Test1234!' }).perform(true);
+    const marketApi2 = buildAuthApi(MarketplaceApi, user2Auth!.token);
+    const bought = await marketApi2.buy({}, { id: listingId }).perform(true);
+    assert(bought !== null, 'body should not be null');
+    assert(bought!.status === 'COMPLETED' || bought!.status === 'SOLD', `expected COMPLETED or SOLD, got ${bought!.status}`);
+  });
+
+  await test('DELETE /api/marketplace/listings/:id — cancel own listing', async () => {
+    // Create another listing then cancel it
+    const listing = await marketApi1.create({ bookId: 'book-020', condition: 'FAIR', price: 5.00 }).perform(true);
+    const resp = await marketApi1.cancel({ id: listing!.id }).getResponse(true);
+    assert(resp.status === 200, `expected 200, got ${resp.status}`);
+  });
+
+  // ── Polling — monitorResponseCode ──
+  console.log('\n── Polling ──');
+
+  await test('monitorResponseCode — succeeds when code matches', async () => {
+    const resp = await healthApi.health().monitorResponseCode(200, 5000, 500);
+    assert(resp.status === 200, `expected 200, got ${resp.status}`);
+  });
+
+  await test('monitorFieldValue — polls until field matches', async () => {
+    const body = await healthApi.health().monitorFieldValue('status', 'healthy', 5000, 500);
+    assert(body !== null, 'body should not be null');
+    assert(body!.status === 'healthy', `expected "healthy"`);
+  });
+
+  // ── ApiResponse.errorBody() ──
+  console.log('\n── ApiResponse.errorBody() ──');
+
+  await test('errorBody() returns null on success', async () => {
+    const resp = await healthApi.health().getResponse();
+    const err = resp.errorBody<ErrorBody>(ErrorBody);
+    assert(err === null, 'errorBody should be null on success');
+  });
+
+  // ── Summary ──
+  console.log(`\n── Results: ${passed} passed, ${failed} failed ──\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "tests"]
+}


### PR DESCRIPTION
## Summary
- Adds `buildRaw()` method to `WasapiClient.Builder` that returns a raw `WasapiClient` instance
- Enables direct `execute()` calls without needing a decorated API class
- Used by `@civitas-cerebrum/singularity` Steps API for generic HTTP methods

## Why
The existing `build(ApiClass)` requires a decorated class with `@GET`/`@POST` methods. For singularity's `steps.apiGet('/path')` pattern, we need a raw client that can call `execute()` with arbitrary method/path/body.

## Test plan
- [x] TypeScript compiles clean
- [x] Existing tests pass
- [ ] Publish as 0.0.1 after merge

Powered by Civitas Cerebrum